### PR TITLE
Adjust canvas node action icons to 16px

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.scss
+++ b/src/app/features/flow/canvas/canvas.component.scss
@@ -43,13 +43,23 @@
 }
 
 /* Override Material button styles */
-.mat-mdc-icon-button {
+:host ::ng-deep .mat-mdc-icon-button {
   width: 16px;
   height: 16px;
   padding: 0;
   border-radius: 4px;
 }
 
-.mat-mdc-icon-button .mdc-icon-button__ripple {
+:host ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target,
+:host ::ng-deep .mat-mdc-icon-button .mdc-icon-button__ripple {
+  width: 16px;
+  height: 16px;
   border-radius: 4px;
+}
+
+:host ::ng-deep .mat-mdc-icon-button fa-icon {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  line-height: 16px;
 }


### PR DESCRIPTION
## Summary
- Ensure edit/delete icon buttons on the flow canvas render at a compact 16px size
- Override Material touch-target and FontAwesome icon dimensions for consistent 16px actions

## Testing
- `npm test` *(fails: ng: not found; dependency installation blocked with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b09d7baec88330ba2e60e1cae14f17