### PR TITLE
Adjust canvas node action icons to 16px, apply Nunito font, and fix question node icon skew

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.scss
+++ b/src/app/features/flow/canvas/canvas.component.scss
@@ -8,6 +8,12 @@
   z-index: 10;
 }
 
+/* Counter-skew for question nodes so icons aren't slanted */
+.node.question .node-actions {
+  transform: skewX(12deg);
+  transform-origin: top right;
+}
+
 .action-btn {
   width: 16px;
   height: 16px;
@@ -43,13 +49,23 @@
 }
 
 /* Override Material button styles */
-.mat-mdc-icon-button {
+:host ::ng-deep .mat-mdc-icon-button {
   width: 16px;
   height: 16px;
   padding: 0;
   border-radius: 4px;
 }
 
-.mat-mdc-icon-button .mdc-icon-button__ripple {
+:host ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target,
+:host ::ng-deep .mat-mdc-icon-button .mdc-icon-button__ripple {
+  width: 16px;
+  height: 16px;
   border-radius: 4px;
+}
+
+:host ::ng-deep .mat-mdc-icon-button fa-icon {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  line-height: 16px;
 }

--- a/src/custom-material-theme.scss
+++ b/src/custom-material-theme.scss
@@ -1,28 +1,28 @@
 @use '@angular/material' as mat;
 
-// Configuração tipográfica personalizada com a fonte Nunito
+// Inicializa mixins e funções base do Angular Material.
+@include mat.core();
+
+// Configuração tipográfica personalizada com a fonte Nunito.
 $nunito-typography: mat.define-typography-config(
   $font-family: 'Nunito, sans-serif',
-  $headline-1: mat.define-typography-level(112px, 112px, 300, 'Nunito, sans-serif'),
-  $headline-2: mat.define-typography-level(56px, 56px, 300, 'Nunito, sans-serif'),
-  $headline-3: mat.define-typography-level(45px, 48px, 400, 'Nunito, sans-serif'),
-  $headline-4: mat.define-typography-level(34px, 40px, 400, 'Nunito, sans-serif'),
-  $headline-5: mat.define-typography-level(24px, 32px, 400, 'Nunito, sans-serif'),
-  $headline-6: mat.define-typography-level(20px, 32px, 500, 'Nunito, sans-serif'),
-  $subtitle-1: mat.define-typography-level(16px, 28px, 400, 'Nunito, sans-serif'),
-  $subtitle-2: mat.define-typography-level(14px, 22px, 500, 'Nunito, sans-serif'),
-  $body-1: mat.define-typography-level(16px, 24px, 400, 'Nunito, sans-serif'),
-  $body-2: mat.define-typography-level(14px, 20px, 400, 'Nunito, sans-serif'),
-  $button: mat.define-typography-level(14px, 14px, 500, 'Nunito, sans-serif'),
-  $caption: mat.define-typography-level(12px, 20px, 400, 'Nunito, sans-serif'),
-  $overline: mat.define-typography-level(12px, 20px, 500, 'Nunito, sans-serif')
+  $headline-1: mat.define-typography-level(112px, 112px, 300),
+  $headline-2: mat.define-typography-level(56px, 56px, 300),
+  $headline-3: mat.define-typography-level(45px, 48px, 400),
+  $headline-4: mat.define-typography-level(34px, 40px, 400),
+  $headline-5: mat.define-typography-level(24px, 32px, 400),
+  $headline-6: mat.define-typography-level(20px, 32px, 500),
+  $subtitle-1: mat.define-typography-level(16px, 28px, 400),
+  $subtitle-2: mat.define-typography-level(14px, 22px, 500),
+  $body-1: mat.define-typography-level(16px, 24px, 400),
+  $body-2: mat.define-typography-level(14px, 20px, 400),
+  $button: mat.define-typography-level(14px, 14px, 500),
+  $caption: mat.define-typography-level(12px, 20px, 400),
+  $overline: mat.define-typography-level(12px, 20px, 500),
 );
 
-// Incluir tipografia do Angular Material com a configuração personalizada
-@include mat.typography-hierarchy($nunito-typography);
-
-// Definir o tema padrão do Azure Blue do Angular Material
-@include mat.all-component-themes(mat.define-theme((
+// Define o tema padrão do Angular Material usando a tipografia Nunito.
+$custom-theme: mat.define-theme((
   color: (
     theme-type: light,
     primary: mat.$azure-blue-palette,
@@ -30,7 +30,9 @@ $nunito-typography: mat.define-typography-config(
     use-system-variables: true,
   ),
   typography: $nunito-typography,
-  density: (
-    scale: 0,
-  )
-)));
+  density: (scale: 0),
+));
+
+// Aplica o tema e a hierarquia tipográfica.
+@include mat.all-component-themes($custom-theme);
+@include mat.typography-hierarchy($custom-theme);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,7 @@ html, body {
   height: 100%;
   margin: 0;
   overflow: hidden;
+  font-family: 'Nunito', sans-serif;
 }
 
 /* Fundo do canvas */


### PR DESCRIPTION
## Summary
- Ensure edit/delete icon buttons on the flow canvas render at a compact 16px size
- Configure Angular Material theme with a Nunito typography config and apply it globally
- Set Nunito as the default font family for the application
- Counter-skew action buttons on question nodes so icons appear upright instead of italic

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcore)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09d7baec88330ba2e60e1cae14f17