### PR TITLE
feat: enable node connections

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.html
+++ b/src/app/features/flow/canvas/canvas.component.html
@@ -2,9 +2,9 @@
     #canvasEl
     class="canvas"
     (mousedown)="startPan($event)"
-    (mousemove)="onPan($event)"
-    (mouseup)="endPan()"
-    (mouseleave)="endPan()"
+    (mousemove)="onMove($event)"
+    (mouseup)="onCanvasMouseUp()"
+    (mouseleave)="onCanvasMouseUp()"
     (click)="deselect()"
     (wheel)="onWheel($event)"
   >
@@ -20,6 +20,10 @@
             [attr.x2]="centerX(e.to)"   [attr.y2]="centerY(e.to)"
             stroke="#b9bed1" stroke-width="2" marker-end="url(#arrow)" />
         </ng-container>
+        <line *ngIf="connectingFrom"
+          [attr.x1]="centerX(connectingFrom!)" [attr.y1]="centerY(connectingFrom!)"
+          [attr.x2]="tempConnection.x" [attr.y2]="tempConnection.y"
+          stroke="#b9bed1" stroke-width="2" marker-end="url(#arrow)" />
         <defs>
           <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
             <path d="M0,0 L0,6 L9,3 z" fill="#b9bed1" />
@@ -35,8 +39,11 @@
         [ngStyle]="{ left: n.position.x + 'px', top: n.position.y + 'px' }"
         class="node-wrapper">
 
+        <div class="handle in" *ngIf="connectingFrom && connectingFrom !== n.id" (mouseup)="finishConnection(n.id, $event)"></div>
+
         <div
           class="node"
+          cdkDragHandle
           [class.question]="n.kind === 'question'"
           [class.condition]="n.kind === 'condition'"
           [class.action]="n.kind === 'action'"
@@ -155,6 +162,8 @@
 
           </ng-container>
         </div>
+
+        <div class="handle out" *ngIf="isSelected(n.id)" (mousedown)="startConnection(n.id, $event)"></div>
       </div>
     </div>
 

--- a/src/app/features/flow/canvas/canvas.component.ts
+++ b/src/app/features/flow/canvas/canvas.component.ts
@@ -10,7 +10,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faCheck, faEdit, faTimes, faTrash, faComment, faGear, faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 
-import { GraphModel, GraphNode } from '../graph.types';
+import { GraphModel, GraphNode, Point } from '../graph.types';
 import { GraphStateService } from '../graph-state.service';
 
 @Component({
@@ -50,6 +50,10 @@ export class CanvasComponent {
   editingNodeId: string | null = null;
   editBuffer: any = {};
 
+  // conexão entre nós
+  connectingFrom: string | null = null;
+  tempConnection: Point = { x: 0, y: 0 };
+
   constructor(private state: GraphStateService) {
     /** Observa o grafo e o id selecionado do serviço (sem depender de getters opcionais) */
     this.graph = toSignal(this.state.graph$, { initialValue: { nodes: [], edges: [] } as GraphModel });
@@ -86,21 +90,50 @@ export class CanvasComponent {
 
   // pan do canvas (arrastar o fundo)
   startPan(ev: MouseEvent) {
-    // só inicia pan se clicou no fundo (fora de um .node)
-    const hitNode = (ev.target as HTMLElement).closest('.node');
-    if (hitNode) return;
+    // só inicia pan se clicou fora de um nó/handle e não estivermos conectando
+    const hit = (ev.target as HTMLElement).closest('.node-wrapper');
+    if (hit || this.connectingFrom) return;
 
     this.panning = true;
     this.panStart = { x: ev.clientX, y: ev.clientY };
     this.panOffsetStart = { ...this.offset };
   }
-  onPan(ev: MouseEvent) {
-    if (!this.panning) return;
-    const dx = (ev.clientX - this.panStart.x) / this.zoom;
-    const dy = (ev.clientY - this.panStart.y) / this.zoom;
-    this.offset = { x: this.panOffsetStart.x + dx, y: this.panOffsetStart.y + dy };
+  onMove(ev: MouseEvent) {
+    if (this.panning) {
+      const dx = (ev.clientX - this.panStart.x) / this.zoom;
+      const dy = (ev.clientY - this.panStart.y) / this.zoom;
+      this.offset = { x: this.panOffsetStart.x + dx, y: this.panOffsetStart.y + dy };
+    }
+
+    if (this.connectingFrom) {
+      const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+      this.tempConnection = {
+        x: (ev.clientX - rect.left - this.offset.x * this.zoom) / this.zoom,
+        y: (ev.clientY - rect.top - this.offset.y * this.zoom) / this.zoom
+      };
+    }
   }
   endPan() { this.panning = false; }
+
+  startConnection(fromId: string, ev: MouseEvent) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    this.connectingFrom = fromId;
+    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    this.tempConnection = {
+      x: (ev.clientX - rect.left - this.offset.x * this.zoom) / this.zoom,
+      y: (ev.clientY - rect.top - this.offset.y * this.zoom) / this.zoom
+    };
+  }
+
+  finishConnection(toId: string | null, ev?: MouseEvent) {
+    ev?.stopPropagation();
+    ev?.preventDefault();
+    if (this.connectingFrom && toId && this.connectingFrom !== toId) {
+      this.state.connect(this.connectingFrom, toId);
+    }
+    this.connectingFrom = null;
+  }
 
   onWheel(event: WheelEvent) {
     event.preventDefault();
@@ -118,6 +151,11 @@ export class CanvasComponent {
 
   zoomIn()  { this.zoom = Math.min(2, this.zoom + 0.1); }
   zoomOut() { this.zoom = Math.max(0.5, this.zoom - 0.1); }
+
+  onCanvasMouseUp() {
+    this.endPan();
+    if (this.connectingFrom) this.finishConnection(null);
+  }
 
   startEdit(node: GraphNode) {
     this.select(node.id);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -98,6 +98,27 @@ html, body {
 /* Arestas */
 .edge-svg { position: absolute; inset: 0; pointer-events: none; }
 
+/* Conectores dos nós */
+.node-wrapper .handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #b9bed1;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 5;
+  cursor: crosshair;
+}
+.node-wrapper .handle.out {
+  right: 0;
+  transform: translate(50%, -50%);
+}
+.node-wrapper .handle.in {
+  left: 0;
+}
+
 /* Painéis */
 .sidebar { width: 320px; border-left:1px solid #eef0f6; padding:12px; background:#fff; }
 .palette { padding:8px; border-bottom:1px solid #eef0f6; background:#fff; display:flex; gap:8px; align-items:center; }


### PR DESCRIPTION
## Summary
- allow dragging from nodes to connect them
- render connector handles and temporary lines
- hide input handles until a connection drag begins
- prevent canvas panning while creating connections

## Testing
- `npm install --legacy-peer-deps --no-progress` *(hangs; terminated)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ccaba700833096f682d5e7a6a8f5