### PR TITLE
feat: enable node connections

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.html
+++ b/src/app/features/flow/canvas/canvas.component.html
@@ -2,9 +2,9 @@
     #canvasEl
     class="canvas"
     (mousedown)="startPan($event)"
-    (mousemove)="onPan($event)"
-    (mouseup)="endPan()"
-    (mouseleave)="endPan()"
+    (mousemove)="onMove($event)"
+    (mouseup)="onCanvasMouseUp()"
+    (mouseleave)="onCanvasMouseUp()"
     (click)="deselect()"
     (wheel)="onWheel($event)"
   >
@@ -13,16 +13,33 @@
       [ngStyle]="{ transform: 'translate(' + offset.x + 'px,' + offset.y + 'px) scale(' + zoom + ')', 'transform-origin': '0 0' }">
 
       <!-- Edges -->
-      <svg class="edge-svg">
+      <svg class="edge-svg" [attr.width]="worldW" [attr.height]="worldH">
         <ng-container *ngFor="let e of graph().edges">
-          <line
-            [attr.x1]="centerX(e.from)" [attr.y1]="centerY(e.from)"
-            [attr.x2]="centerX(e.to)"   [attr.y2]="centerY(e.to)"
-            stroke="#b9bed1" stroke-width="2" marker-end="url(#arrow)" />
+          <g (mouseenter)="hoveredEdgeId = e.id" (mouseleave)="hoveredEdgeId = null">
+            <path
+              [attr.d]="pathBetween(e.from, e.to)"
+              fill="none"
+              stroke-width="2"
+              [attr.stroke]="hoveredEdgeId === e.id ? '#ff4d4f' : '#b9bed1'"
+              [attr.marker-end]="hoveredEdgeId === e.id ? 'url(#arrow-red)' : 'url(#arrow)'" />
+            <foreignObject *ngIf="hoveredEdgeId === e.id" [attr.x]="edgeMidpoint(e).x - 12" [attr.y]="edgeMidpoint(e).y - 12" width="24" height="24">
+              <div xmlns="http://www.w3.org/1999/xhtml">
+                <button class="edge-delete" (click)="removeEdge(e.id, $event)">
+                  <fa-icon [icon]="faTrash"></fa-icon>
+                </button>
+              </div>
+            </foreignObject>
+          </g>
         </ng-container>
+        <path *ngIf="connectingFrom"
+          [attr.d]="pathToPoint(connectingFrom!, tempConnection)"
+          fill="none" stroke="#b9bed1" stroke-width="2" marker-end="url(#arrow)" />
         <defs>
           <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
             <path d="M0,0 L0,6 L9,3 z" fill="#b9bed1" />
+          </marker>
+          <marker id="arrow-red" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L9,3 z" fill="#ff4d4f" />
           </marker>
         </defs>
       </svg>
@@ -31,12 +48,16 @@
       <div
         *ngFor="let n of graph().nodes"
         cdkDrag
+        (cdkDragMoved)="dragMove(n, $event)"
         (cdkDragEnded)="dragEnd(n, $event)"
         [ngStyle]="{ left: n.position.x + 'px', top: n.position.y + 'px' }"
         class="node-wrapper">
 
+        <div class="handle in" *ngIf="connectingFrom && connectingFrom !== n.id" (mouseup)="finishConnection(n.id, $event)"></div>
+
         <div
           class="node"
+          cdkDragHandle
           [class.question]="n.kind === 'question'"
           [class.condition]="n.kind === 'condition'"
           [class.action]="n.kind === 'action'"
@@ -146,7 +167,7 @@
               </ng-template>
             </div>
 
-            <!-- End = Circle -->
+            <!-- End = Capsule -->
             <div *ngSwitchCase="'end'" class="end">
               <div class="content">
                 <div class="title">FIM</div>
@@ -155,6 +176,8 @@
 
           </ng-container>
         </div>
+
+        <div class="handle out" *ngIf="isSelected(n.id) && n.kind !== 'end'" (mousedown)="startConnection(n.id, $event)"></div>
       </div>
     </div>
 

--- a/src/app/features/flow/canvas/canvas.component.scss
+++ b/src/app/features/flow/canvas/canvas.component.scss
@@ -126,11 +126,11 @@
   font-family: inherit;
 }
 
-/* Estilo para o nó final (círculo com borda preta) */
+/* Estilo para o nó final (terminador em forma de cápsula) */
 .node.end {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 120px;
+  height: 50px;
+  border-radius: 25px;
   background-color: #ffffff; /* Fundo branco igual aos demais nós */
   display: flex;
   align-items: center;

--- a/src/app/features/flow/canvas/canvas.component.ts
+++ b/src/app/features/flow/canvas/canvas.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { NgFor, NgIf, NgStyle, NgSwitch, NgSwitchCase, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DragDropModule, CdkDragEnd } from '@angular/cdk/drag-drop';
+import { DragDropModule, CdkDragEnd, CdkDragMove } from '@angular/cdk/drag-drop';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -10,7 +10,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faCheck, faEdit, faTimes, faTrash, faComment, faGear, faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 
-import { GraphModel, GraphNode } from '../graph.types';
+import { GraphModel, GraphNode, Point, GraphEdge } from '../graph.types';
 import { GraphStateService } from '../graph-state.service';
 
 @Component({
@@ -47,8 +47,21 @@ export class CanvasComponent {
   selectedId;
   graph;
 
+  // dimensões do "mundo" para posicionamento e arestas
+  readonly worldW = 2000;
+  readonly worldH = 1200;
+
   editingNodeId: string | null = null;
   editBuffer: any = {};
+
+  // conexão entre nós
+  connectingFrom: string | null = null;
+  tempConnection: Point = { x: 0, y: 0 };
+
+  hoveredEdgeId: string | null = null;
+
+  // posições temporárias enquanto arrasta
+  private dragOffsets: Record<string, Point> = {};
 
   constructor(private state: GraphStateService) {
     /** Observa o grafo e o id selecionado do serviço (sem depender de getters opcionais) */
@@ -57,16 +70,37 @@ export class CanvasComponent {
 
   }
 
-  // helpers p/ arestas (centros aproximados por tipo)
-  centerX(id: string) {
-    const n = this.graph().nodes.find(nn => nn.id === id)!;
-    const w = n.kind === 'condition' ? 120 : n.kind === 'action' ? 180 : 200;
-    return n.position.x + w / 2;
+
+  private nodeSize(kind: string) {
+    const w = kind === 'condition' ? 120 : kind === 'action' ? 180 : kind === 'end' ? 80 : 200;
+    const h = kind === 'condition' ? 120 : kind === 'action' ? 80 : kind === 'end' ? 80 : 90;
+    return { w, h };
   }
-  centerY(id: string) {
+
+  private outPoint(id: string): Point {
     const n = this.graph().nodes.find(nn => nn.id === id)!;
-    const h = n.kind === 'condition' ? 120 : n.kind === 'action' ? 80 : 90;
-    return n.position.y + h / 2;
+    const { w, h } = this.nodeSize(n.kind);
+    const off = this.dragOffsets[id] || { x: 0, y: 0 };
+    return { x: n.position.x + off.x + w, y: n.position.y + off.y + h / 2 };
+  }
+  private inPoint(id: string): Point {
+    const n = this.graph().nodes.find(nn => nn.id === id)!;
+    const { h } = this.nodeSize(n.kind);
+    const off = this.dragOffsets[id] || { x: 0, y: 0 };
+    return { x: n.position.x + off.x, y: n.position.y + off.y + h / 2 };
+  }
+
+  private path(p1: Point, p2: Point) {
+    const mx = (p1.x + p2.x) / 2;
+    return `M ${p1.x} ${p1.y} C ${mx} ${p1.y}, ${mx} ${p2.y}, ${p2.x} ${p2.y}`;
+  }
+
+  pathBetween(fromId: string, toId: string) {
+    return this.path(this.outPoint(fromId), this.inPoint(toId));
+  }
+
+  pathToPoint(fromId: string, to: Point) {
+    return this.path(this.outPoint(fromId), to);
   }
 
   // seleção
@@ -75,6 +109,10 @@ export class CanvasComponent {
   deselect()              { this.state.select(null); }
 
   // drag do nó
+  dragMove(n: GraphNode, ev: CdkDragMove) {
+    this.dragOffsets[n.id] = ev.source.getFreeDragPosition();
+  }
+
   dragEnd(n: GraphNode, ev: CdkDragEnd) {
     const delta = ev.source.getFreeDragPosition();
     this.state.moveNode(n.id, {
@@ -82,25 +120,55 @@ export class CanvasComponent {
       y: n.position.y + delta.y
     });
     ev.source.reset();
+    delete this.dragOffsets[n.id];
   }
 
   // pan do canvas (arrastar o fundo)
   startPan(ev: MouseEvent) {
-    // só inicia pan se clicou no fundo (fora de um .node)
-    const hitNode = (ev.target as HTMLElement).closest('.node');
-    if (hitNode) return;
+    // só inicia pan se clicou fora de um nó/handle e não estivermos conectando
+    const hit = (ev.target as HTMLElement).closest('.node-wrapper');
+    if (hit || this.connectingFrom) return;
 
     this.panning = true;
     this.panStart = { x: ev.clientX, y: ev.clientY };
     this.panOffsetStart = { ...this.offset };
   }
-  onPan(ev: MouseEvent) {
-    if (!this.panning) return;
-    const dx = (ev.clientX - this.panStart.x) / this.zoom;
-    const dy = (ev.clientY - this.panStart.y) / this.zoom;
-    this.offset = { x: this.panOffsetStart.x + dx, y: this.panOffsetStart.y + dy };
+  onMove(ev: MouseEvent) {
+    if (this.panning) {
+      const dx = (ev.clientX - this.panStart.x) / this.zoom;
+      const dy = (ev.clientY - this.panStart.y) / this.zoom;
+      this.offset = { x: this.panOffsetStart.x + dx, y: this.panOffsetStart.y + dy };
+    }
+
+    if (this.connectingFrom) {
+      const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+      this.tempConnection = {
+        x: (ev.clientX - rect.left - this.offset.x * this.zoom) / this.zoom,
+        y: (ev.clientY - rect.top - this.offset.y * this.zoom) / this.zoom
+      };
+    }
   }
   endPan() { this.panning = false; }
+
+  startConnection(fromId: string, ev: MouseEvent) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    this.connectingFrom = fromId;
+    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    this.tempConnection = {
+      x: (ev.clientX - rect.left - this.offset.x * this.zoom) / this.zoom,
+      y: (ev.clientY - rect.top - this.offset.y * this.zoom) / this.zoom
+    };
+  }
+
+  finishConnection(toId: string | null, ev?: MouseEvent) {
+    ev?.stopPropagation();
+    ev?.preventDefault();
+    if (this.connectingFrom && toId && this.connectingFrom !== toId) {
+      this.state.connect(this.connectingFrom, toId);
+    }
+    this.connectingFrom = null;
+  }
 
   onWheel(event: WheelEvent) {
     event.preventDefault();
@@ -118,6 +186,22 @@ export class CanvasComponent {
 
   zoomIn()  { this.zoom = Math.min(2, this.zoom + 0.1); }
   zoomOut() { this.zoom = Math.max(0.5, this.zoom - 0.1); }
+
+  onCanvasMouseUp() {
+    this.endPan();
+    if (this.connectingFrom) this.finishConnection(null);
+  }
+
+  removeEdge(id: string, ev: MouseEvent) {
+    ev.stopPropagation();
+    this.state.removeEdge(id);
+  }
+
+  edgeMidpoint(e: GraphEdge): Point {
+    const p1 = this.outPoint(e.from);
+    const p2 = this.inPoint(e.to);
+    return { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 };
+  }
 
   startEdit(node: GraphNode) {
     this.select(node.id);
@@ -144,13 +228,11 @@ export class CanvasComponent {
   get viewBox() {
     const cw = this.canvasRef?.nativeElement.clientWidth || 1;
     const ch = this.canvasRef?.nativeElement.clientHeight || 1;
-    const worldW = 2000;
-    const worldH = 1200;
     return {
-      width: 120 * (cw / (worldW * this.zoom)),
-      height: 80 * (ch / (worldH * this.zoom)),
-      left: -this.offset.x / (worldW * this.zoom) * 120,
-      top: -this.offset.y / (worldH * this.zoom) * 80
+      width: 120 * (cw / (this.worldW * this.zoom)),
+      height: 80 * (ch / (this.worldH * this.zoom)),
+      left: -this.offset.x / (this.worldW * this.zoom) * 120,
+      top: -this.offset.y / (this.worldH * this.zoom) * 80
     };
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -96,7 +96,42 @@ html, body {
 }
 
 /* Arestas */
-.edge-svg { position: absolute; inset: 0; pointer-events: none; }
+.edge-svg { position: absolute; inset: 0; }
+.edge-svg path { pointer-events: stroke; cursor: pointer; }
+.edge-delete {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #b9bed1;
+  background: #fff;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #ff4d4f;
+  padding: 0;
+}
+
+/* Conectores dos nós */
+.node-wrapper .handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #b9bed1;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 5;
+  cursor: crosshair;
+}
+.node-wrapper .handle.out {
+  right: 0;
+  transform: translate(50%, -50%);
+}
+.node-wrapper .handle.in {
+  left: 0;
+}
 
 /* Painéis */
 .sidebar { width: 320px; border-left:1px solid #eef0f6; padding:12px; background:#fff; }


### PR DESCRIPTION
## Summary
- allow dragging from nodes to connect them
- render connector handles and temporary lines
- hide input handles until a connection drag begins
- prevent canvas panning while creating connections
- draw edge lines across the full canvas and track world dimensions
- curve edge paths and update connections while nodes drag
- allow clicking edges to remove connections
- render final form node as a pill-shaped terminator with no outgoing handle
- highlight edges on hover and show a delete button for removal

## Testing
- `npm install --legacy-peer-deps --no-progress` *(fails: Possible EventEmitter memory leak detected. MaxListenersExceededWarning)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ccaba700833096f682d5e7a6a8f5