### PR TITLE
feat(flow): display inspector panel in flow designer

### DIFF
--- a/src/app/features/flow/flow-designer/flow-designer.component.scss
+++ b/src/app/features/flow/flow-designer/flow-designer.component.scss
@@ -1,0 +1,29 @@
+/* Layout for flow designer */
+.palette {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.palette .spacer {
+  flex: 1;
+}
+
+.flow-shell {
+  display: flex;
+  height: calc(100vh - 64px);
+}
+
+.flow-shell app-canvas {
+  flex: 1;
+}
+
+.flow-shell app-inspector {
+  width: 320px;
+  border-left: 1px solid #e0e0e0;
+  background: #fafafa;
+  padding: 12px;
+  overflow: auto;
+}

--- a/src/app/features/flow/flow-designer/flow-designer.component.ts
+++ b/src/app/features/flow/flow-designer/flow-designer.component.ts
@@ -3,23 +3,26 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { PaletteComponent } from '../palette/palette.component';
 import { CanvasComponent } from '../canvas/canvas.component';
+import { InspectorComponent } from '../inspector/inspector.component';
 import { GraphStateService } from '../graph-state.service';
 import { GraphMapperService } from '../graph-mapper.service';
 
 @Component({
   selector: 'app-flow-designer',
   standalone: true,
-  imports: [MatButtonModule, MatIconModule, PaletteComponent, CanvasComponent],
+  imports: [MatButtonModule, MatIconModule, PaletteComponent, CanvasComponent, InspectorComponent],
   template: `
   <div class="palette">
     <app-palette (add)="onAdd($event)"></app-palette>
-    <span style="flex:1"></span>
+    <span class="spacer"></span>
     <button mat-stroked-button color="primary" (click)="exportForm()"><mat-icon>play_circle</mat-icon> Exportar para FormDefinition</button>
   </div>
   <div class="flow-shell">
     <app-canvas></app-canvas>
+    <app-inspector></app-inspector>
   </div>
-  `
+  `,
+  styleUrl: './flow-designer.component.scss'
 })
 export class FlowDesignerComponent {
   constructor(private state: GraphStateService, private mapper: GraphMapperService) {}

--- a/src/app/features/flow/inspector/inspector.component.scss
+++ b/src/app/features/flow/inspector/inspector.component.scss
@@ -1,0 +1,5 @@
+.sidebar {
+  h3 {
+    margin-top: 0;
+  }
+}

--- a/src/app/features/flow/inspector/inspector.component.spec.ts
+++ b/src/app/features/flow/inspector/inspector.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InspectorComponent } from './inspector.component';
 
@@ -8,7 +9,7 @@ describe('InspectorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [InspectorComponent]
+      imports: [InspectorComponent, NoopAnimationsModule]
     })
     .compileComponents();
 

--- a/src/app/features/flow/inspector/options-dialog.component.ts
+++ b/src/app/features/flow/inspector/options-dialog.component.ts
@@ -1,0 +1,54 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { Option } from '../../../shared/models/form-models';
+
+@Component({
+  selector: 'app-options-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatIconModule, FormsModule, CommonModule],
+  template: `
+    <h2 mat-dialog-title>Configurar Opções</h2>
+    <div mat-dialog-content>
+      <div *ngFor="let opt of options; let i=index" class="option-row">
+        <mat-form-field appearance="outline">
+          <mat-label>Label</mat-label>
+          <input matInput [(ngModel)]="opt.label">
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Valor</mat-label>
+          <input matInput [(ngModel)]="opt.value">
+        </mat-form-field>
+        <button mat-icon-button color="warn" aria-label="Excluir" (click)="remove(i)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+      <button mat-stroked-button type="button" (click)="add()">Adicionar Opção</button>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancelar</button>
+      <button mat-raised-button color="primary" (click)="save()">Salvar</button>
+    </div>
+  `,
+  styles: [`
+    .option-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    mat-form-field { flex: 1; }
+  `]
+})
+export class OptionsDialogComponent {
+  options: Option[] = [];
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: {options: Option[]},
+    public dialogRef: MatDialogRef<OptionsDialogComponent>
+  ) {
+    this.options = data.options ? data.options.map(o => ({...o})) : [];
+  }
+  add(){ this.options.push({ value: '', label: '' }); }
+  remove(i: number){ this.options.splice(i,1); }
+  save(){ this.dialogRef.close(this.options); }
+}

--- a/src/app/shared/models/form-models.ts
+++ b/src/app/shared/models/form-models.ts
@@ -6,6 +6,7 @@ export interface VisibilityCondition { expression?: string; }
 
 export interface Question {
   id: string; type: QuestionType; label: string; helpText?: string; required?: boolean;
+  trueLabel?: string; falseLabel?: string;
   options?: Option[]; placeholder?: string; defaultValue?: any; validations?: ValidationRule[]; visibility?: VisibilityCondition;
   weight?: number; scoreMap?: Record<string, number>;
 }


### PR DESCRIPTION
## Summary
- include InspectorComponent in flow designer template
- style palette/canvas layout so inspector appears as sidebar

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1a66e808330b3d1c33f947dc14c