### PR TITLE
feat: enhance question node editing

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.html
+++ b/src/app/features/flow/canvas/canvas.component.html
@@ -97,44 +97,12 @@
           <ng-container [ngSwitch]="n.kind">
 
             <!-- Question = Parallelogram -->
-            <div *ngSwitchCase="'question'" class="content">
-              <div class="title"><fa-icon [icon]="faComment"></fa-icon> Questão #{{ n.data.seq }}</div>
-              <ng-container *ngIf="editingNodeId === n.id; else viewQuestion">
-                <div class="field-container" [class.focused]="focused === 'label'">
-                  <input
-                    type="text"
-                    [(ngModel)]="editBuffer.label"
-                    class="clean-input"
-                    (focus)="focused = 'label'"
-                    (blur)="focused = null"
-                    placeholder="Digite a pergunta"
-                  />
-                </div>
-                <div class="field-container" [class.focused]="focused === 'type'">
-                  <select
-                    [(ngModel)]="editBuffer.type"
-                    class="clean-input"
-                    (focus)="focused = 'type'"
-                    (blur)="focused = null"
-                  >
-                    <option value="text">Texto</option>
-                    <option value="boolean">Boolean</option>
-                    <option value="integer">Inteiro</option>
-                    <option value="double">Double</option>
-                    <option value="select">Lista</option>
-                    <option value="radio">Radio</option>
-                    <option value="checkbox">Checkbox</option>
-                    <option value="date">Data</option>
-                    <option value="datetime">Data e Hora</option>
-                    <option value="image">Imagem</option>
-                  </select>
-                </div>
-              </ng-container>
-              <ng-template #viewQuestion>
-                <div style="font-size:18px">{{ n.data.label || 'Pergunta' }}</div>
-                <div class="sub">{{ n.data.type | titlecase }}</div>
-              </ng-template>
-            </div>
+            <app-node-question
+              *ngSwitchCase="'question'"
+              [node]="n"
+              [editing]="editingNodeId === n.id"
+              [editBuffer]="editBuffer"
+            ></app-node-question>
 
             <!-- Condition = Diamond -->
             <div *ngSwitchCase="'condition'" class="diamond">

--- a/src/app/features/flow/canvas/canvas.component.ts
+++ b/src/app/features/flow/canvas/canvas.component.ts
@@ -8,9 +8,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCheck, faEdit, faTimes, faTrash, faComment, faGear, faCodeBranch } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faEdit, faTimes, faTrash, faGear, faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 import { GraphModel, GraphNode, Point, GraphEdge } from '../graph.types';
 import { GraphStateService } from '../graph-state.service';
+import { NodeQuestionComponent } from '../node-question/node-question.component';
 
 @Component({
   selector: 'app-canvas',
@@ -19,7 +20,7 @@ import { GraphStateService } from '../graph-state.service';
   imports: [
     NgFor, NgIf, NgStyle, NgSwitch, NgSwitchCase, TitleCasePipe,
     DragDropModule, MatButtonModule, MatFormFieldModule, MatInputModule,
-    MatSelectModule, FontAwesomeModule, FormsModule
+    MatSelectModule, FontAwesomeModule, FormsModule, NodeQuestionComponent
   ],
   templateUrl: './canvas.component.html'
 })
@@ -31,7 +32,6 @@ export class CanvasComponent {
   faTrash = faTrash;
   faCheck = faCheck;
   faTimes = faTimes;
-  faComment = faComment;
   faGear = faGear;
   faCodeBranch = faCodeBranch;
 

--- a/src/app/features/flow/node-question/node-question.component.html
+++ b/src/app/features/flow/node-question/node-question.component.html
@@ -1,1 +1,63 @@
-<p>node-question works!</p>
+<div class="content">
+  <div class="title"><fa-icon [icon]="faComment"></fa-icon> Questão #{{ node.data.seq }}</div>
+  <ng-container *ngIf="editing; else viewQuestion">
+    <div class="field-container" [class.focused]="focused === 'label'">
+      <input
+        type="text"
+        [(ngModel)]="editBuffer.label"
+        class="clean-input"
+        (focus)="focused = 'label'"
+        (blur)="focused = null"
+        placeholder="Digite a pergunta"
+      />
+    </div>
+    <div class="field-container" [class.focused]="focused === 'type'">
+      <select
+        [(ngModel)]="editBuffer.type"
+        class="clean-input"
+        (focus)="focused = 'type'"
+        (blur)="focused = null"
+      >
+        <option value="text">Texto</option>
+        <option value="boolean">Boolean</option>
+        <option value="integer">Inteiro</option>
+        <option value="double">Double</option>
+        <option value="select">Lista</option>
+        <option value="radio">Radio</option>
+        <option value="checkbox">Checkbox</option>
+        <option value="date">Data</option>
+        <option value="datetime">Data e Hora</option>
+        <option value="image">Imagem</option>
+      </select>
+    </div>
+    <div *ngIf="editBuffer.type === 'boolean'">
+      <div class="field-container" [class.focused]="focused === 'trueLabel'">
+        <input
+          type="text"
+          [(ngModel)]="editBuffer.trueLabel"
+          class="clean-input"
+          (focus)="focused = 'trueLabel'"
+          (blur)="focused = null"
+          placeholder="Verdadeiro"
+        />
+      </div>
+      <div class="field-container" [class.focused]="focused === 'falseLabel'">
+        <input
+          type="text"
+          [(ngModel)]="editBuffer.falseLabel"
+          class="clean-input"
+          (focus)="focused = 'falseLabel'"
+          (blur)="focused = null"
+          placeholder="Falso"
+        />
+      </div>
+    </div>
+    <div *ngIf="['select','radio','checkbox'].includes(editBuffer.type)">
+      <button class="options-btn" type="button" (click)="openOptions()">Configurar Opções</button>
+    </div>
+  </ng-container>
+  <ng-template #viewQuestion>
+    <div style="font-size:18px">{{ node.data.label || 'Pergunta' }}</div>
+    <div class="sub">{{ node.data.type | titlecase }}</div>
+  </ng-template>
+</div>

--- a/src/app/features/flow/node-question/node-question.component.scss
+++ b/src/app/features/flow/node-question/node-question.component.scss
@@ -1,0 +1,52 @@
+:host {
+  display: block;
+}
+
+.title {
+  font-weight: bold;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sub {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.field-container {
+  background: #f4f4f7;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  height: 40px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  transition: border 0.2s ease;
+  max-width: 280px;
+  margin-bottom: 8px;
+}
+
+.field-container.focused {
+  border-color: #3f51b5;
+}
+
+.clean-input {
+  font-size: 15px;
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 100%;
+  font-family: inherit;
+}
+
+.options-btn {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid #3f51b5;
+  background: #ffffff;
+  color: #3f51b5;
+  cursor: pointer;
+  font-size: 12px;
+}

--- a/src/app/features/flow/node-question/node-question.component.spec.ts
+++ b/src/app/features/flow/node-question/node-question.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NodeQuestionComponent } from './node-question.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('NodeQuestionComponent', () => {
   let component: NodeQuestionComponent;
@@ -8,7 +9,7 @@ describe('NodeQuestionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NodeQuestionComponent]
+      imports: [NodeQuestionComponent, NoopAnimationsModule]
     })
     .compileComponents();
 

--- a/src/app/features/flow/node-question/node-question.component.ts
+++ b/src/app/features/flow/node-question/node-question.component.ts
@@ -1,11 +1,40 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { NgIf, TitleCasePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faComment } from '@fortawesome/free-solid-svg-icons';
+import { GraphNode } from '../graph.types';
+import { GraphStateService } from '../graph-state.service';
+import { OptionsDialogComponent } from '../inspector/options-dialog.component';
 
 @Component({
   selector: 'app-node-question',
-  imports: [],
+  standalone: true,
+  imports: [NgIf, FormsModule, MatDialogModule, FontAwesomeModule, TitleCasePipe, OptionsDialogComponent],
   templateUrl: './node-question.component.html',
   styleUrl: './node-question.component.scss'
 })
 export class NodeQuestionComponent {
+  @Input() node!: GraphNode;
+  @Input() editing = false;
+  @Input() editBuffer: any = {};
 
+  faComment = faComment;
+  focused: 'label' | 'type' | 'trueLabel' | 'falseLabel' | null = null;
+
+  constructor(private dialog: MatDialog, private state: GraphStateService) {}
+
+  openOptions() {
+    const dialogRef = this.dialog.open(OptionsDialogComponent, {
+      width: '400px',
+      data: { options: this.editBuffer.options || [] }
+    });
+    dialogRef.afterClosed().subscribe(res => {
+      if (res) {
+        this.editBuffer.options = res;
+        this.state.updateNode(this.node.id, { ...this.node.data, options: res });
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- show true/false labels for boolean questions
- add "Configurar Opções" dialog for select, radio and checkbox questions
- wire node-question updates into graph state and edit mode

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b701d215e88330b8acab5e91313d9a