### PR TITLE
feat: conditionally show inspector

### DIFF
--- a/src/app/features/flow/flow-designer/flow-designer.component.ts
+++ b/src/app/features/flow/flow-designer/flow-designer.component.ts
@@ -19,7 +19,7 @@ import { GraphMapperService } from '../graph-mapper.service';
   </div>
   <div class="flow-shell">
     <app-canvas></app-canvas>
-    <app-inspector></app-inspector>
+    <app-inspector *ngIf="(state.selectedId$ | async) as sel && sel"></app-inspector>
   </div>
   `,
   styleUrl: './flow-designer.component.scss'


### PR DESCRIPTION
## Summary
- display inspector only when a node is selected using async-selectedId

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden fetching @angular/core)*

------
https://chatgpt.com/codex/tasks/task_e_68b701d04e2c83308f84ff7d60bfe8b1