### PR TITLE
fix condition node connections

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.html
+++ b/src/app/features/flow/canvas/canvas.component.html
@@ -17,7 +17,7 @@
         <ng-container *ngFor="let e of graph().edges">
           <g (mouseenter)="hoveredEdgeId = e.id" (mouseleave)="hoveredEdgeId = null">
             <path
-              [attr.d]="pathBetween(e.from, e.to)"
+              [attr.d]="pathBetween(e)"
               fill="none"
               stroke-width="2"
               [attr.stroke]="hoveredEdgeId === e.id ? '#ff4d4f' : '#b9bed1'"
@@ -113,7 +113,7 @@
             *ngFor="let condition of n.data.conditions; let i = index"
             class="handle out condition-handle"
             [attr.data-condition-id]="condition.id"
-            (mousedown)="startConnection(n.id, $event)"
+            (mousedown)="startConnection(n.id, $event, condition.id)"
             [ngStyle]="{ top: (20 + i * 30) + 'px' }">
             <span class="handle-label">{{ condition.name || 'Condição ' + (i + 1) }}</span>
           </div>

--- a/src/app/features/flow/canvas/canvas.component.scss
+++ b/src/app/features/flow/canvas/canvas.component.scss
@@ -139,7 +139,7 @@
 /* Handles de condição */
 .condition-handle {
   position: absolute;
-  right: -12px;
+  right: -12px !important;
   width: 12px;
   height: 12px;
   background: #5c6bc0;
@@ -147,6 +147,7 @@
   border-radius: 50%;
   cursor: crosshair;
   z-index: 5;
+  transform: none !important;
 }
 
 .condition-handle .handle-label {


### PR DESCRIPTION
## Summary
- ensure condition edges originate from the center of their respective handles
- remove inherited transform from condition handles for precise alignment

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcore)*
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca5b74648330b7eb50edbb195ac0