### PR TITLE
fix condition node connections

### DIFF
--- a/src/app/features/flow/canvas/canvas.component.html
+++ b/src/app/features/flow/canvas/canvas.component.html
@@ -17,7 +17,7 @@
         <ng-container *ngFor="let e of graph().edges">
           <g (mouseenter)="hoveredEdgeId = e.id" (mouseleave)="hoveredEdgeId = null">
             <path
-              [attr.d]="pathBetween(e.from, e.to)"
+              [attr.d]="pathBetween(e)"
               fill="none"
               stroke-width="2"
               [attr.stroke]="hoveredEdgeId === e.id ? '#ff4d4f' : '#b9bed1'"
@@ -113,7 +113,7 @@
             *ngFor="let condition of n.data.conditions; let i = index"
             class="handle out condition-handle"
             [attr.data-condition-id]="condition.id"
-            (mousedown)="startConnection(n.id, $event)"
+            (mousedown)="startConnection(n.id, $event, condition.id)"
             [ngStyle]="{ top: (20 + i * 30) + 'px' }">
             <span class="handle-label">{{ condition.name || 'Condição ' + (i + 1) }}</span>
           </div>

--- a/src/app/features/flow/canvas/canvas.component.scss
+++ b/src/app/features/flow/canvas/canvas.component.scss
@@ -139,24 +139,22 @@
 /* Handles de condição */
 .condition-handle {
   position: absolute;
-  right: -12px;
+  right: -12px !important;
   width: 12px;
   height: 12px;
-  background: #5c6bc0;
-  border: 2px solid white;
+  background: #a66bff;
+  border: 2px solid #a66bff;
   border-radius: 50%;
   cursor: crosshair;
   z-index: 5;
+  transform: none !important;
 }
 
 .condition-handle .handle-label {
   position: absolute;
   left: 20px;
   top: -8px;
-  background: #5c6bc0;
-  color: white;
-  padding: 2px 6px;
-  border-radius: 4px;
+  color: #a66bff;
   font-size: 10px;
   white-space: nowrap;
   pointer-events: none;

--- a/src/app/features/flow/node-condition/node-condition.component.html
+++ b/src/app/features/flow/node-condition/node-condition.component.html
@@ -1,13 +1,11 @@
 <div class="diamond">
   <div class="content">
     <div class="title">
-      <fa-icon [icon]="faCodeBranch"></fa-icon> 
+      <fa-icon [icon]="faCodeBranch"></fa-icon>
       Condição #{{ node.data.seq }}
     </div>
-    <div class="conditions-list">
-      <div *ngFor="let condition of node.data.conditions" class="condition-item">
-        {{ condition.name || 'Condição ' + (node.data.conditions.indexOf(condition) + 1) }}
-      </div>
+    <div class="condition-count">
+      {{ node.data.conditions.length }} {{ node.data.conditions.length === 1 ? 'condição' : 'condições' }}
     </div>
   </div>
 </div>

--- a/src/app/features/flow/node-condition/node-condition.component.scss
+++ b/src/app/features/flow/node-condition/node-condition.component.scss
@@ -3,7 +3,7 @@
   height: 120px;
   transform: rotate(45deg);
   background: white;
-  border: 2px solid #5c6bc0;
+  border: 2px solid #a66bff;
   position: relative;
   display: flex;
   align-items: center;
@@ -24,17 +24,6 @@
   margin-bottom: 8px;
 }
 
-.conditions-list {
+.condition-count {
   font-size: 11px;
-  max-height: 80px;
-  overflow-y: auto;
-}
-
-.condition-item {
-  padding: 2px 0;
-  border-bottom: 1px solid #eee;
-}
-
-.condition-item:last-child {
-  border-bottom: none;
 }


### PR DESCRIPTION
## Summary
- show only the number of configured conditions inside the condition node
- match condition handle colors to the node and remove label background

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcore)*
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca5b74648330b7eb50edbb195ac0