### PR TITLE
Use button toggles for condition member type

### DIFF
--- a/src/app/features/flow/inspector/inspector.component.ts
+++ b/src/app/features/flow/inspector/inspector.component.ts
@@ -5,7 +5,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatRadioModule } from '@angular/material/radio';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faSave, faTimes, faTrash, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { GraphStateService } from '../graph-state.service';
@@ -18,7 +17,7 @@ import { ConditionEditorComponent } from '../node-condition/condition-editor/con
   standalone: true,
   imports: [
     NgIf, NgSwitch, NgSwitchCase, NgFor, ReactiveFormsModule, 
-    MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatRadioModule,
+    MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule,
     FontAwesomeModule, ConditionEditorComponent
   ],
   template: `

--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.scss
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.scss
@@ -31,7 +31,19 @@
   margin-bottom: 16px;
 }
 
-.value-toggle mat-radio-group {
-  display: flex;
-  gap: 16px;
+.value-toggle mat-button-toggle-group {
+  display: inline-flex;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.value-toggle mat-button-toggle {
+  flex: 1;
+  font-size: 0.8rem;
+  text-transform: none;
+}
+
+.value-toggle mat-button-toggle:not(:first-child) {
+  border-left: 1px solid currentColor;
 }

--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
@@ -5,7 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatRadioModule } from '@angular/material/radio';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types';
@@ -21,7 +21,7 @@ import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types'
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
-    MatRadioModule,
+    MatButtonToggleModule,
     FontAwesomeModule
   ],
   template: `
@@ -41,11 +41,15 @@ import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types'
       <div class="value-section">
         <h5>Primeiro Valor</h5>
         <div class="value-toggle">
-          <mat-radio-group formControlName="valueType" aria-label="Valor ou Pergunta">
-            <mat-radio-button value="fixed">Valor Fixo</mat-radio-button>
-            <mat-radio-button value="question">Pergunta</mat-radio-button>
-            <mat-radio-button value="score">Score da Pergunta</mat-radio-button>
-          </mat-radio-group>
+          <mat-button-toggle-group
+            color="primary"
+            formControlName="valueType"
+            aria-label="Valor ou Pergunta"
+          >
+            <mat-button-toggle value="fixed">Valor Fixo</mat-button-toggle>
+            <mat-button-toggle value="question">Pergunta</mat-button-toggle>
+            <mat-button-toggle value="score">Score da Pergunta</mat-button-toggle>
+          </mat-button-toggle-group>
         </div>
 
         <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('valueType')?.value === 'fixed'">
@@ -75,11 +79,15 @@ import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types'
       <div class="compare-value-section">
         <h5>Segundo Valor</h5>
         <div class="value-toggle">
-          <mat-radio-group formControlName="compareValueType" aria-label="Valor ou Pergunta">
-            <mat-radio-button value="fixed">Valor Fixo</mat-radio-button>
-            <mat-radio-button value="question">Pergunta</mat-radio-button>
-            <mat-radio-button value="score">Score da Pergunta</mat-radio-button>
-          </mat-radio-group>
+          <mat-button-toggle-group
+            color="primary"
+            formControlName="compareValueType"
+            aria-label="Valor ou Pergunta"
+          >
+            <mat-button-toggle value="fixed">Valor Fixo</mat-button-toggle>
+            <mat-button-toggle value="question">Pergunta</mat-button-toggle>
+            <mat-button-toggle value="score">Score da Pergunta</mat-button-toggle>
+          </mat-button-toggle-group>
         </div>
 
         <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('compareValueType')?.value === 'fixed'">
@@ -185,8 +193,8 @@ export class ConditionEditorComponent implements OnInit {
     if (!questionType || !this.questionTypeOperators[questionType]) {
       return this.operators;
     }
-    
-    return this.operators.filter(op => 
+
+    return this.operators.filter(op =>
       this.questionTypeOperators[questionType].includes(op.value)
     );
   }


### PR DESCRIPTION
## Summary
- replace radio inputs with `mat-button-toggle-group` for condition member type selection
- remove unused radio module import and update styling
- style toggle groups with primary theme and segmented appearance

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcore)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68becf359f888330b0b48b5bcb772308