### PR TITLE
Restrict condition node operators and available questions

### DIFF
--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
@@ -122,13 +122,13 @@ export class ConditionEditorComponent implements OnInit {
   ];
 
   questionTypeOperators: Record<string, string[]> = {
-    'text': ['==', '!=', 'in', 'contains'],
+    'text': ['==', '!=', 'contains'],
     'integer': ['==', '!=', '>', '>=', '<', '<='],
     'double': ['==', '!=', '>', '>=', '<', '<='],
     'boolean': ['==', '!='],
-    'select': ['==', '!=', 'in'],
+    'select': ['==', '!=', 'contains'],
     'radio': ['==', '!='],
-    'checkbox': ['==', '!=', 'in', 'contains'],
+    'checkbox': ['==', '!=', 'contains'],
     'date': ['==', '!=', '>', '>=', '<', '<='],
     'datetime': ['==', '!=', '>', '>=', '<', '<='],
     'image': ['==', '!='],


### PR DESCRIPTION
## Summary
- Limit operator choices by question type: strings allow equals, not equals, contains; booleans allow equals or not equals
- Exclude image fields and only show questions linked to the condition node

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: sh: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee817eec48330b0417d933db6514b