### PR TITLE
feat: add expression condition option

### DIFF
--- a/src/app/features/flow/graph.types.ts
+++ b/src/app/features/flow/graph.types.ts
@@ -6,7 +6,8 @@ export interface GraphModel { nodes:GraphNode[]; edges:GraphEdge[]; }
 
 export interface QuestionNodeData { id:string; label:string; type:'text'|'integer'|'double'|'boolean'|'select'|'radio'|'checkbox'|'date'|'datetime'|'image'; score?:number; trueLabel?:string; falseLabel?:string; options?:any[]; helpText?:string; seq?:number; }
 
-export interface SingleCondition {
+export interface ComparisonCondition {
+  type: 'comparison';
   id: string;
   name: string;
   valueType: 'fixed' | 'question' | 'score'; // Toggle para o primeiro valor
@@ -18,9 +19,17 @@ export interface SingleCondition {
   compareQuestionId?: string;
 }
 
-export interface ConditionNodeData { 
-  conditions: SingleCondition[]; 
-  seq?: number; 
+export interface ExpressionCondition {
+  type: 'expression';
+  id: string;
+  expression: string;
+}
+
+export type Condition = ComparisonCondition | ExpressionCondition;
+
+export interface ConditionNodeData {
+  conditions: Condition[];
+  seq?: number;
 }
 
 export interface ActionNodeData { type:'openForm'|'emitAlert'|'webhook'|'setTag'|'setField'; params?:Record<string,any>; seq?:number; }

--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
@@ -8,7 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types';
+import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.types';
 
 @Component({
   selector: 'app-condition-editor',
@@ -101,7 +101,7 @@ import { SingleCondition, QuestionNodeData, GraphNode } from '../../graph.types'
   styleUrl: './condition-editor.component.scss'
 })
 export class ConditionEditorComponent implements OnInit {
-  @Input() condition!: SingleCondition;
+  @Input() condition!: ComparisonCondition;
   @Input() index!: number;
   @Input() availableQuestions: GraphNode<QuestionNodeData>[] = [];
   @Output() remove = new EventEmitter<void>();

--- a/src/app/features/flow/node-condition/expression-condition-editor/expression-condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/expression-condition-editor/expression-condition-editor.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { ExpressionCondition } from '../../graph.types';
+
+@Component({
+  selector: 'app-expression-condition-editor',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    FontAwesomeModule
+  ],
+  template: `
+    <div class="condition-editor">
+      <div class="condition-header">
+        <h4>Condição {{ index + 1 }}</h4>
+        <button mat-icon-button type="button" (click)="remove.emit()" *ngIf="index > 0">
+          <fa-icon [icon]="faTrash"></fa-icon>
+        </button>
+      </div>
+      <mat-form-field appearance="outline" style="width:100%">
+        <mat-label>Expressão</mat-label>
+        <input matInput [formControl]="expressionControl">
+      </mat-form-field>
+    </div>
+  `,
+  styleUrl: '../condition-editor/condition-editor.component.scss'
+})
+export class ExpressionConditionEditorComponent implements OnInit {
+  @Input() condition!: ExpressionCondition;
+  @Input() index!: number;
+  @Output() remove = new EventEmitter<void>();
+
+  faTrash = faTrash;
+  expressionControl = new FormControl('');
+
+  ngOnInit() {
+    this.expressionControl.setValue(this.condition.expression);
+    this.expressionControl.valueChanges.subscribe(value => {
+      this.condition.expression = value || '';
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- allow adding expression or comparison conditions
- support editing expression-based conditions with new component

## Testing
- `npm test` *(fails: ng not found)*
- `npm install --legacy-peer-deps` *(fails: peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68c035e059448330884e7a723120d047