### PR TITLE
feat: support condition and score options

### DIFF
--- a/src/app/features/flow/flow-designer/flow-designer.component.ts
+++ b/src/app/features/flow/flow-designer/flow-designer.component.ts
@@ -52,10 +52,14 @@ export class FlowDesignerComponent {
             valueType: 'fixed',
             value: '',
             questionId: '',
+            questionValueType: 'value',
+            conditionId: '',
             operator: '==',
             compareValueType: 'fixed',
             compareValue: '',
-            compareQuestionId: ''
+            compareQuestionId: '',
+            compareQuestionValueType: 'value',
+            compareConditionId: ''
           }]
         }, pos);
       }

--- a/src/app/features/flow/graph.types.ts
+++ b/src/app/features/flow/graph.types.ts
@@ -10,13 +10,17 @@ export interface ComparisonCondition {
   type: 'comparison';
   id: string;
   name: string;
-  valueType: 'fixed' | 'question' | 'score'; // Toggle para o primeiro valor
+  valueType: 'fixed' | 'question' | 'condition';
   value?: any;
   questionId?: string;
+  questionValueType?: 'value' | 'score';
+  conditionId?: string;
   operator?: '==' | '!=' | '>' | '>=' | '<' | '<=' | 'in' | 'contains';
-  compareValueType: 'fixed' | 'question' | 'score'; // Toggle para o segundo valor
+  compareValueType: 'fixed' | 'question' | 'condition';
   compareValue?: any;
   compareQuestionId?: string;
+  compareQuestionValueType?: 'value' | 'score';
+  compareConditionId?: string;
 }
 
 export interface ExpressionCondition {

--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
@@ -8,7 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.types';
+import { ComparisonCondition, QuestionNodeData, GraphNode, Condition } from '../../graph.types';
 
 @Component({
   selector: 'app-condition-editor',
@@ -41,10 +41,10 @@ import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.ty
       <div class="value-section">
         <h5>Primeiro Valor</h5>
         <div class="value-toggle">
-          <mat-button-toggle-group formControlName="valueType" aria-label="Valor ou Pergunta">
-            <mat-button-toggle value="fixed">Valor Fixo</mat-button-toggle>
+          <mat-button-toggle-group formControlName="valueType" aria-label="Tipo do primeiro valor">
+            <mat-button-toggle value="fixed">Constante</mat-button-toggle>
             <mat-button-toggle value="question">Pergunta</mat-button-toggle>
-            <mat-button-toggle value="score">Score da Pergunta</mat-button-toggle>
+            <mat-button-toggle value="condition" *ngIf="availableConditions.length">Condição</mat-button-toggle>
           </mat-button-toggle-group>
         </div>
 
@@ -53,11 +53,28 @@ import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.ty
           <input matInput formControlName="value">
         </mat-form-field>
 
-        <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('valueType')?.value === 'question' || conditionForm.get('valueType')?.value === 'score'">
-          <mat-label>Pergunta</mat-label>
-          <mat-select formControlName="questionId">
-            <mat-option *ngFor="let question of availableQuestions" [value]="question.data.id">
-              {{ question.data.label }}
+        <ng-container *ngIf="conditionForm.get('valueType')?.value === 'question'">
+          <mat-form-field appearance="outline" style="width:100%">
+            <mat-label>Pergunta</mat-label>
+            <mat-select formControlName="questionId">
+              <mat-option *ngFor="let question of availableQuestions" [value]="question.data.id">
+                {{ question.data.label }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <div class="value-toggle">
+            <mat-button-toggle-group formControlName="questionValueType" aria-label="Valor ou Score">
+              <mat-button-toggle value="value">Valor</mat-button-toggle>
+              <mat-button-toggle value="score">Score</mat-button-toggle>
+            </mat-button-toggle-group>
+          </div>
+        </ng-container>
+
+        <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('valueType')?.value === 'condition'">
+          <mat-label>Condição</mat-label>
+          <mat-select formControlName="conditionId">
+            <mat-option *ngFor="let cond of availableConditions" [value]="cond.id">
+              {{ cond.name || 'Condição' }}
             </mat-option>
           </mat-select>
         </mat-form-field>
@@ -75,10 +92,10 @@ import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.ty
       <div class="compare-value-section">
         <h5>Segundo Valor</h5>
         <div class="value-toggle">
-          <mat-button-toggle-group formControlName="compareValueType" aria-label="Valor ou Pergunta">
-            <mat-button-toggle value="fixed">Valor Fixo</mat-button-toggle>
-            <mat-button-toggle value="question">Pergunta</mat-button-toggle>
-            <mat-button-toggle value="score">Score da Pergunta</mat-button-toggle>
+          <mat-button-toggle-group formControlName="compareValueType" aria-label="Tipo do segundo valor">
+            <mat-button-toggle value="fixed" *ngIf="conditionForm.get('valueType')?.value !== 'condition'">Constante</mat-button-toggle>
+            <mat-button-toggle value="question" *ngIf="conditionForm.get('valueType')?.value !== 'condition'">Pergunta</mat-button-toggle>
+            <mat-button-toggle value="condition" *ngIf="availableConditions.length">Condição</mat-button-toggle>
           </mat-button-toggle-group>
         </div>
 
@@ -87,11 +104,28 @@ import { ComparisonCondition, QuestionNodeData, GraphNode } from '../../graph.ty
           <input matInput formControlName="compareValue">
         </mat-form-field>
 
-        <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('compareValueType')?.value === 'question' || conditionForm.get('compareValueType')?.value === 'score'">
-          <mat-label>Pergunta</mat-label>
-          <mat-select formControlName="compareQuestionId">
-            <mat-option *ngFor="let question of availableQuestionsForComparison" [value]="question.data.id">
-              {{ question.data.label }}
+        <ng-container *ngIf="conditionForm.get('compareValueType')?.value === 'question'">
+          <mat-form-field appearance="outline" style="width:100%">
+            <mat-label>Pergunta</mat-label>
+            <mat-select formControlName="compareQuestionId">
+              <mat-option *ngFor="let question of availableQuestionsForComparison" [value]="question.data.id">
+                {{ question.data.label }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <div class="value-toggle">
+            <mat-button-toggle-group formControlName="compareQuestionValueType" aria-label="Valor ou Score">
+              <mat-button-toggle value="value">Valor</mat-button-toggle>
+              <mat-button-toggle value="score">Score</mat-button-toggle>
+            </mat-button-toggle-group>
+          </div>
+        </ng-container>
+
+        <mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('compareValueType')?.value === 'condition'">
+          <mat-label>Condição</mat-label>
+          <mat-select formControlName="compareConditionId">
+            <mat-option *ngFor="let cond of availableConditions" [value]="cond.id">
+              {{ cond.name || 'Condição' }}
             </mat-option>
           </mat-select>
         </mat-form-field>
@@ -104,6 +138,7 @@ export class ConditionEditorComponent implements OnInit {
   @Input() condition!: ComparisonCondition;
   @Input() index!: number;
   @Input() availableQuestions: GraphNode<QuestionNodeData>[] = [];
+  @Input() availableConditions: Condition[] = [];
   @Output() remove = new EventEmitter<void>();
   
   faTrash = faTrash;
@@ -142,16 +177,28 @@ export class ConditionEditorComponent implements OnInit {
       valueType: new FormControl('fixed'),
       value: new FormControl(''),
       questionId: new FormControl(''),
+      questionValueType: new FormControl('value'),
+      conditionId: new FormControl(''),
       operator: new FormControl('=='),
       compareValueType: new FormControl('fixed'),
       compareValue: new FormControl(''),
-      compareQuestionId: new FormControl('')
+      compareQuestionId: new FormControl(''),
+      compareQuestionValueType: new FormControl('value'),
+      compareConditionId: new FormControl('')
     });
   }
   
   ngOnInit() {
     this.conditionForm.patchValue(this.condition);
-    
+
+    this.conditionForm.get('valueType')?.valueChanges.subscribe(v => {
+      if (v === 'condition') {
+        this.conditionForm.get('compareValueType')?.setValue('condition');
+      } else if (this.conditionForm.get('compareValueType')?.value === 'condition') {
+        this.conditionForm.get('compareValueType')?.setValue('fixed');
+      }
+    });
+
     // Update parent condition when form changes
     this.conditionForm.valueChanges.subscribe(value => {
       // Update only the specific fields that have changed
@@ -173,7 +220,9 @@ export class ConditionEditorComponent implements OnInit {
 
   get selectedQuestionType(): string | undefined {
     const valueType = this.conditionForm.get('valueType')?.value;
-    if (valueType === 'score') return 'score';
+    if (valueType !== 'question') return undefined;
+
+    if (this.conditionForm.get('questionValueType')?.value === 'score') return 'score';
 
     const selectedQuestionId = this.conditionForm.get('questionId')?.value;
     if (!selectedQuestionId) return undefined;


### PR DESCRIPTION
## Summary
- allow comparison conditions to use constants, questions or other conditions
- let users choose question score or value when comparing
- expose upstream conditions for selection in condition editor

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c04433818083309106afdbb946c64a