### PR TITLE
Reset unused fields when toggling between condition types

### DIFF
--- a/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
+++ b/src/app/features/flow/node-condition/condition-editor/condition-editor.component.ts
@@ -242,8 +242,32 @@ export class ConditionEditorComponent implements OnInit {
     valueTypeCtrl?.valueChanges.subscribe(v => {
       if (v === 'condition') {
         compareValueTypeCtrl?.setValue('condition');
-      } else if (compareValueTypeCtrl?.value === 'condition') {
-        compareValueTypeCtrl?.setValue('fixed');
+        this.conditionForm.patchValue({
+          value: '',
+          questionId: '',
+          questionValueType: 'value'
+        });
+      } else {
+        if (compareValueTypeCtrl?.value === 'condition') {
+          compareValueTypeCtrl?.setValue('fixed');
+        }
+        this.conditionForm.patchValue({
+          conditionId: ''
+        });
+      }
+    });
+
+    compareValueTypeCtrl?.valueChanges.subscribe(v => {
+      if (v === 'condition') {
+        this.conditionForm.patchValue({
+          compareValue: '',
+          compareQuestionId: '',
+          compareQuestionValueType: 'value'
+        });
+      } else {
+        this.conditionForm.patchValue({
+          compareConditionId: ''
+        });
       }
     });
 


### PR DESCRIPTION
## Summary
- Clear unrelated form fields when valueType switches to or from condition
- Reset comparison fields when compareValueType changes to or from condition

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden for @angular/core)*

------
https://chatgpt.com/codex/tasks/task_e_68c0810290988330b1072a2f37a2f2bb