### PR TITLE
Ajusta comparações para opções

### DIFF
--- a/projects/forms-workflow/src/lib/features/flow/inspector/inspector.component.html
+++ b/projects/forms-workflow/src/lib/features/flow/inspector/inspector.component.html
@@ -18,7 +18,11 @@
 
           <mat-checkbox color="primary" formControlName="required">Obrigatória</mat-checkbox>
 
-          <lib-control-material-number label="Pontuação da Resposta" [smaller]="true" style="width:100%; display: grid;">
+          <lib-control-material-number
+            *ngIf="![8,9,10].includes(fgQ.get('type')?.value?.id)"
+            label="Pontuação da Resposta"
+            [smaller]="true"
+            style="width:100%; display: grid;">
             <input formControlName="score" />
           </lib-control-material-number>
           

--- a/projects/forms-workflow/src/lib/features/flow/node-condition/condition-editor/condition-editor.component.html
+++ b/projects/forms-workflow/src/lib/features/flow/node-condition/condition-editor/condition-editor.component.html
@@ -96,18 +96,31 @@
       </div>
 
       <ng-container *ngIf="conditionForm.get('compareValueType')?.value === 'fixed'">
-        <ng-container *ngIf="shouldShowBooleanFixedSelector; else compareFixedTextField">
-          <div class="value-toggle">
-            <mat-button-toggle-group formControlName="compareValue" aria-label="Valor booleano">
-              <mat-button-toggle [value]="true">{{ booleanFixedLabels.trueLabel }}</mat-button-toggle>
-              <mat-button-toggle [value]="false">{{ booleanFixedLabels.falseLabel }}</mat-button-toggle>
-            </mat-button-toggle-group>
-          </div>
-        </ng-container>
-        <ng-template #compareFixedTextField>
-          <lib-control-material label="Valor" [smaller]="true" style="width:100%; display: grid;">
+        <ng-container *ngIf="shouldUseOptionFixedSelector; else nonOptionFixedField">
+          <lib-control-material-select
+            [selectList]="optionFixedChoices"
+            bindId="id"
+            bindLabel="label"
+            label="Valor"
+            [smaller]="true"
+            style="width:100%; display: grid;">
             <input formControlName="compareValue" />
-          </lib-control-material>
+          </lib-control-material-select>
+        </ng-container>
+        <ng-template #nonOptionFixedField>
+          <ng-container *ngIf="shouldShowBooleanFixedSelector; else compareFixedTextField">
+            <div class="value-toggle">
+              <mat-button-toggle-group formControlName="compareValue" aria-label="Valor booleano">
+                <mat-button-toggle [value]="true">{{ booleanFixedLabels.trueLabel }}</mat-button-toggle>
+                <mat-button-toggle [value]="false">{{ booleanFixedLabels.falseLabel }}</mat-button-toggle>
+              </mat-button-toggle-group>
+            </div>
+          </ng-container>
+          <ng-template #compareFixedTextField>
+            <lib-control-material label="Valor" [smaller]="true" style="width:100%; display: grid;">
+              <input formControlName="compareValue" />
+            </lib-control-material>
+          </ng-template>
         </ng-template>
       </ng-container>
       <!--<mat-form-field appearance="outline" style="width:100%" *ngIf="conditionForm.get('compareValueType')?.value === 'fixed'">

--- a/projects/forms-workflow/src/lib/features/run/run-form/run-form.component.ts
+++ b/projects/forms-workflow/src/lib/features/run/run-form/run-form.component.ts
@@ -472,6 +472,23 @@ export class RunFormComponent implements OnInit {
     return undefined;
   }
 
+  private normalizeOptionAnswer(value: any): string | string[] | null {
+    if (Array.isArray(value)) {
+      const mapped = value
+        .map(item => this.extractComparableOptionValue(item))
+        .filter((item): item is string | number | boolean => item !== undefined && item !== null)
+        .map(item => String(item));
+      return mapped;
+    }
+
+    const comparable = this.extractComparableOptionValue(value);
+    if (comparable === undefined || comparable === null) {
+      return null;
+    }
+
+    return String(comparable);
+  }
+
   private formatTemporalAnswer(value: any, typeId: number): string {
     if (value === null || value === undefined || value === '') {
       return '—';
@@ -790,6 +807,10 @@ export class RunFormComponent implements OnInit {
       const typeId = this.questionTypeIds.get(questionId);
       if (typeId === 5) {
         return this.normalizeBooleanAnswer(questionId, value);
+      }
+      if (typeId !== undefined && [8, 9, 10].includes(typeId)) {
+        const normalized = this.normalizeOptionAnswer(value);
+        return normalized ?? value;
       }
       return value;
     }


### PR DESCRIPTION
## Summary
- hide the question score input for option-based question types
- allow comparison conditions to pick option values as constants and normalize them to option identifiers
- evaluate option answers by their identifiers when resolving comparison conditions
- avoid locking the condition editor by keeping question selector values as question ids

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f903579883309255260d10b2e807)